### PR TITLE
Avoid calling done() too early/repeatedly

### DIFF
--- a/tasks/dom_munger.js
+++ b/tasks/dom_munger.js
@@ -108,7 +108,6 @@ module.exports = function(grunt) {
 
     var options = this.options({});
     var done = this.async();
-    var countdown = 0;
 
     if (this.filesSrc.length > 1 && this.data.dest){
       grunt.log.error('Dest cannot be specified with multiple src files.');
@@ -128,21 +127,15 @@ module.exports = function(grunt) {
         }
       }).forEach(function(f){
 
-        countdown++;
-
         var srcContents = grunt.file.read(f);
 
         var $ = cheerio.load(srcContents);
         processFile(f,dest,options,$);
 
-        countdown --;
-        if (countdown === 0){
-          done();
-        }          
-
       });
     });
 
+    done();
   });
 
 };


### PR DESCRIPTION
forEach is synchronous so you can just call done() once it's done. 

The current logic was kinda broken since it increments countdown to 1 then decrements it to 0 then if it's 0 it calls done, and it does that at every iteration so it calls done too many times and breaks any following async task in the grunt pipeline.
