### PR TITLE
Added support for arrays of configurations in each option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,12 +51,37 @@ module.exports = function(grunt) {
           read: {selector:'script',attribute:'src',writeto:'test',isPath:true}
         },
         src: 'test/fixtures/index.html'
+      },
+      test3: {
+        options: {
+          read: [
+            {selector:'link',attribute:'href',writeto:'mylinks',isPath:true},
+            {selector:'script[src]',attribute:'src',writeto:'myscripts',isPath:true}
+          ],
+          remove: ['#removeMe'],
+          update: [{selector:'html',attribute:'appmode',value:'production'}],
+          prefix: [{selector:'link',attribute:'href',value:'project-name/'}],
+          suffix: [{selector:'html',attribute:'version',value:'.0.1'}],
+          append: [{selector:'body',html:'<div id="appended">Im being appended</div>'}],
+          prepend: [{selector:'body',html:'<span>Im being prepended</span>'}],
+          text: [
+            {selector:'title',text:'CHANGED TITLE'},
+            {selector:'#sample2',text:'Ive been updated via callback'},
+            {selector:'#filepath',text:'Made from test/fixtures/index.html'}
+          ],
+        },
+        src: 'test/fixtures/index.html',
+        dest: 'tmp/index.html'
       }
     },
     concat: {
       test: {
         src:['test/fixtures/css0.css','<%= dom_munger.data.mylinks %>'],
         dest:'tmp/concated.css'
+      },
+      test3: {
+        src:['<%= dom_munger.data.myscripts %>'],
+        dest:'tmp/concated.js'
       }
     },
     // Unit tests.

--- a/test/expected/concated.js
+++ b/test/expected/concated.js
@@ -1,0 +1,6 @@
+function js1(){
+	
+}
+function js2(){
+	
+}

--- a/test/expected/index.html
+++ b/test/expected/index.html
@@ -5,6 +5,8 @@
 		<link href="project-name/css1.css" rel="stylesheet">
 		<link href="project-name/css2.css" rel="stylesheet">
 		<link href="project-name/css3.css" rel="stylesheet">
+		<script src="js1.js"></script>
+		<script src="js2.js"></script>
 	</head>
 	<body><span>Im being prepended</span>
 		

--- a/test/fixtures/index.html
+++ b/test/fixtures/index.html
@@ -5,6 +5,8 @@
 		<link href="css1.css" rel="stylesheet">
 		<link href="css2.css" rel="stylesheet">
 		<link href="css3.css" rel="stylesheet">
+		<script src="js1.js"></script>
+		<script src="js2.js"></script>
 	</head>
 	<body>
 		<div id="removeMe">I no longer have the will to live.</div>

--- a/test/fixtures/js1.js
+++ b/test/fixtures/js1.js
@@ -1,0 +1,3 @@
+function js1(){
+	
+}

--- a/test/fixtures/js2.js
+++ b/test/fixtures/js2.js
@@ -1,0 +1,3 @@
+function js2(){
+	
+}


### PR DESCRIPTION
Now the following format is also supported:

``` js
options: {
        read: [{selector:'link',attribute:'href',writeto:'myCssRefs',isPath:true}],
        remove: ['#removeMe'],
        update: [{selector:'html',attribute:'appmode', value:'production'}],
        prefix: [{selector:'link',attribute:'href',value:'project-name/'}],
        suffix: [{selector:'html',attribute:'version',value:'.0.1'}],
        append: [{selector:'body',html:'<div id="appended">Im being appended</div>'}],
        prepend: [{selector:'body',html:'<span>Im being prepended</span>'}],
        text: [{selector:'title',text:'My App'}]
}
```

I'm aware `remove` doesn't really need to be an array, but I figured devs are probably going to complain about it eventually (instead of using commas) so I added support for it too. I did not add array support to `callback` though.

This allows you to do things like reading multiple chunks to multiple data stores, as well as performing all other options in different ways without having to fire multiple task targets.
