### PR TITLE
Added possibility for callback function to cancel updating source file.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -73,6 +73,14 @@ module.exports = function(grunt) {
         src: 'test/fixtures/index.html',
         dest: 'tmp/index.html'
       },
+      test_callback_read: {
+        options: {
+          callback: function ($, file) {
+            return false;
+          }
+        },
+        src: 'test/fixtures/formatted.html'
+      },
       test_order: { //order should be read then remove then any other update operations
         options: {
           read: [

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ grunt.initConfig({
 ```
 
 #### options.callback
-When you feel like bustin loose.  Set a callback function and use the passed JQuery object to do anything you want to the HTML.  The second argument to the callback is the name of the file being processed.
+When you feel like bustin loose.  Set a callback function and use the passed JQuery object to do anything you want to the HTML.  The second argument to the callback is the name of the file being processed.  If the callback function returns `false` the source file is assumed to only have been read and no output will be written.
 
 ```js
 grunt.initConfig({

--- a/tasks/dom_munger.js
+++ b/tasks/dom_munger.js
@@ -144,9 +144,8 @@ module.exports = function(grunt) {
     }
 
     if (options.callback){
-       options.callback($, f);
-       //just assume its updating something
-       updated = true;
+      // don't update if callback function returns false
+      updated = options.callback($, f) !== false;
     }
 
     if (updated){

--- a/test/dom_munger_test.js
+++ b/test/dom_munger_test.js
@@ -57,5 +57,14 @@ exports.dom_munger = {
     test.equal(actual, expected, 'should save the read elements ensuring that the elements were read before the HTML was updated.');
 
     test.done();
+  },
+  callback_return_false: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('test/fixtures/formatted.html');
+    var expected = grunt.file.read('test/fixtures/formatted_expected.html');
+    test.equal(actual, expected, 'should not modify the source files when callback returns false.');
+
+    test.done();
   }
 };

--- a/test/fixtures/formatted.html
+++ b/test/fixtures/formatted.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html version="1">
+<head>
+    <title></title>
+    <link href="css1.css" rel="stylesheet">
+    <link href="css2.css" rel="stylesheet">
+    <link href="css3.css" rel="stylesheet">
+  </head>
+  <body>
+    <div data-attr-foo="foo"
+      data-attr-bar="bar"
+      data-attr-baz="baz">
+      Formatted
+    </div>
+  </body>
+</html>

--- a/test/fixtures/formatted_expected.html
+++ b/test/fixtures/formatted_expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html version="1">
+<head>
+    <title></title>
+    <link href="css1.css" rel="stylesheet">
+    <link href="css2.css" rel="stylesheet">
+    <link href="css3.css" rel="stylesheet">
+  </head>
+  <body>
+    <div data-attr-foo="foo"
+      data-attr-bar="bar"
+      data-attr-baz="baz">
+      Formatted
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Solution to #26. The check for update uses the callback return value and !== false for backwards compatibility. A callback return value of true could also work, but it seems more dangerous.
