### PR TITLE
Added ability to read contents

### DIFF
--- a/tasks/dom_munger.js
+++ b/tasks/dom_munger.js
@@ -31,7 +31,7 @@ module.exports = function(grunt) {
         } else {
 
           var vals = $(option.selector).map(function(i,elem){
-            return $(elem).attr(option.attribute);
+            return (option.attribute === 'html') ? $(elem).html() : $(elem).attr(option.attribute);
           });
 
           vals = vals.filter(function(item){


### PR DESCRIPTION
Allow the read function to take an “html” attribute to get the contents of the selector in addition to an individual attribute.  I wanted to use this to take the contents of some header CSS and export it into its own external file, but couldn't do it via the attributes only.