### PR TITLE
Extend for a Source Map onto the writeto variable 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ grunt.initConfig({
 Note: each option (except callback) requires a `selector`.  This can be any valid CSS selector.  Also, each option (except callback) can be a single object (or String for `remove`) or an array of objects/Strings.  In this way, one target may perform multiple actions of the same type.
 
 #### options.read
-Extract the value of a given attribute from the set of matched elements then set the values into `dom_munger.data.{writeto}`.  A typical use-case is to grab the script references from your html file and pass that to `concat`,`uglify`, or `cssmin`.
+Extract the value of a given attribute from the set of matched elements then set the values into `dom_munger.data.{writeto}`. In case of a source array, a source map object is available under `dom_munger.data.{writeto}SrcMap`. A typical use-case is to grab the script references from your html file and pass that to `concat`,`uglify`, or `cssmin`.
 
 ```js
 grunt.initConfig({

--- a/tasks/dom_munger.js
+++ b/tasks/dom_munger.js
@@ -44,7 +44,20 @@ module.exports = function(grunt) {
               return path.join(relativeTo,val);
             });
           }
+          // provide SrcMap in case of multiple sources
+          var srcMap = grunt.config(['dom_munger','data',option.writeto + "SrcMap"]);
+          if (srcMap === undefined) {
+            srcMap = {}
+          }
 
+          if (vals === undefined) {
+            srcMap[f] = [];
+          } else {
+            srcMap[f] = vals;
+          }
+          
+          grunt.config(['dom_munger','data',option.writeto + "SrcMap"] , srcMap);
+          
           grunt.config(['dom_munger','data',option.writeto],vals);
           grunt.log.writeln('Wrote ' + (option.selector + '.' + option.attribute).cyan + ' to ' + ('dom_munger.data.'+option.writeto).cyan);
         }


### PR DESCRIPTION
Adds a source map of retrieved values according to the processed source, to make use of a source arrays. Extends to `{writeto}SrcMap`. Fixes #32 
#### Example

``` javascript
grunt.initConfig({
        dom_munger: {
            your_target: {
                options: {
                    read: {
                        selector: 'script',
                        attribute: 'src',
                        // ->
                        writeto: 'jsRefs',
                        // <-
                        isPath: true
                    }
                },
                // Going through multiple html files, collecting javascript references
                src: ['html/*.html']
            },
        },
        log: {}
    });
```
#### Array of last processed document (_jsRefs_):

`grunt.config.process(<%= dom_munger.data.jsRefs %>)`

``` js
   [ 'html/assets/javascript5.js',
     'html/assets/javascript6.js' ]
```
#### Object source map with arrays of last processed document (_jsRefsSrcMap_):

`grunt.config.process(<%= dom_munger.data.jsRefsSrcMap %>)`

``` js
{ 'html/first.html': 
   [ 'html/assets/javascript1.js',
     'html/assets/javascript2.js' ],
  'html/second.html': 
   [ 'html/assets/javascript3.js',
     'html/assets/javascript4.js' ],
  'html/third.html': 
   [ 'html/assets/javascript5.js',
     'html/assets/javascript6.js' ]
}
```
