### PR TITLE
Fixed option isPath

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "grunt-contrib-nodeunit": "~0.3.0"
   },
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
This commit fix a bug when using `option.isPath`
[grunt.file.expand](http://gruntjs.com/api/grunt.file#grunt.file.expand) returns an array and [path.dirname](https://nodejs.org/api/path.html#path_path_dirname_path) requires a string.