### PR TITLE
Convert file path to a string to avoid "Warning: Path must be a string"

### DIFF
--- a/tasks/dom_munger.js
+++ b/tasks/dom_munger.js
@@ -39,7 +39,8 @@ module.exports = function(grunt) {
           });
 
           if (option.isPath){
-            var relativeTo = path.dirname(grunt.file.expand(f));
+            var file = grunt.file.expand(f).toString();
+            var relativeTo = path.dirname(file);
             vals = vals.map(function(val){
               return path.join(relativeTo,val);
             });


### PR DESCRIPTION
If "isPath" is set, I had problems with grunt.file.expand returning an array, which grunt.dirname did not appear to like and threw out the error:

`Warning: Path must be a string. Received [ 'index.html' ] Use --force to continue.`

Converting the array to a String with toString seems to solve the issue. In addition if there are older versions of grunt/node that aren't having grunt.file.expand pass an array, calling toString() on a String should have no effect. This should make this backwards compatible.